### PR TITLE
Adding resolve-type

### DIFF
--- a/src/jml/core.clj
+++ b/src/jml/core.clj
@@ -217,11 +217,14 @@
         :else x))
     expr)))
 
+(defn java-array? [obj]
+  (.isArray (class obj)))
+
 (defn resolve-method-type [expr]
   (if (= (type expr) org.objectweb.asm.commons.Method)
     expr
     (let [[_ method-name return-type arg-types] expr
-          arg-types (if (.isArray (class arg-types)) arg-types
+          arg-types (if (java-array? arg-types) arg-types
                         (into-array Type (map resolve-type arg-types)))]
       (Method. method-name (resolve-type return-type) arg-types))))
 
@@ -237,10 +240,6 @@
         :int Type/INT_TYPE
         :long Type/LONG_TYPE
         :bool Type/BOOLEAN_TYPE
-
-        :Integer  (Type/getType (Class/forName "java.lang.Integer"))
-
-        ;; need to add handling Class
         (throw (ex-info (format  "[resolve-type] Unknown Keyword expr-type %s" expr-type) {:expr expr-type})))
       (= t java.lang.String) (Type/getType (Class/forName expr-type))
       :else
@@ -252,15 +251,6 @@
     owner (update :owner resolve-type)
     field-type (update :field-type resolve-type)
     method (update :method resolve-method-type)))
-
-
-
-#_(make-fn {:class-name "CallOther"
-          :code
-          (list 'invoke-static {:owner (Type/getType (Class/forName "Thing"))
-                                :method (Method. "invoke" Type/INT_TYPE (into-array Type []))})
-          :arg-types []
-          :return-type Type/INT_TYPE})
 
 
 (defn linearize* [code]

--- a/src/jml/core.clj
+++ b/src/jml/core.clj
@@ -220,14 +220,6 @@
 (defn java-array? [obj]
   (.isArray (class obj)))
 
-(defn resolve-method-type [expr]
-  (if (= (type expr) org.objectweb.asm.commons.Method)
-    expr
-    (let [[_ method-name return-type arg-types] expr
-          arg-types (if (java-array? arg-types) arg-types
-                        (into-array Type (map resolve-type arg-types)))]
-      (Method. method-name (resolve-type return-type) arg-types))))
-
 (defn resolve-type [expr-type]
   (let [t (type expr-type)]
     (cond   ;;if expr is already of asm.Type
@@ -250,6 +242,16 @@
 
       :else
       (throw (ex-info (format  "[resolve-type] Unknown type %s" expr-type) {:expr expr-type})))))
+
+(defn resolve-method-type [expr]
+  (if (= (type expr) org.objectweb.asm.commons.Method)
+    expr
+    (let [[_ method-name return-type arg-types] expr
+          arg-types (if (java-array? arg-types) arg-types
+                        (into-array Type (map resolve-type arg-types)))]
+      (Method. method-name (resolve-type return-type) arg-types))))
+
+
 
 (defn resolve-props-type [{:keys [type owner field-type result-type method] :as props}]
   (cond-> props

--- a/src/jml/core.clj
+++ b/src/jml/core.clj
@@ -583,7 +583,7 @@
      {:name "SubInt"
       :fields []}
      {:name "Arg"
-      :fields [{:name "argIndex" :type Type/INT_TYPE}]}
+      :fields [{:name "argIndex" :type :int}]}
      {:name "Math"
       :fields [{:name "op" :type :int}
                {:name "opType" :type (Type/getType Type)}]}
@@ -592,9 +592,9 @@
                {:name "name" :type (Type/getType String)}
                {:name "resultType" :type (Type/getType Type)}]}
      {:name "Int"
-      :fields [{:name "intValue" :type Type/INT_TYPE}]}
+      :fields [{:name "intValue" :type :int}]}
      {:name "Bool"
-      :fields [{:name "boolValue" :type Type/BOOLEAN_TYPE}]}]}))
+      :fields [{:name "boolValue" :type :bool}]}]}))
 
 [(Code/PlusInt)
  (Code/SubInt)

--- a/src/jml/core.clj
+++ b/src/jml/core.clj
@@ -231,9 +231,12 @@
 (defn resolve-type [expr-type]
   (let [t (type expr-type)]
     (cond   ;;if expr is already of asm.Type
-      (= t Type) expr-type
+      (= t Type)
+      expr-type
+
       (= t clojure.lang.Keyword)
       (case expr-type
+        :asm-type   (Type/getType Type) ;; :asm-type because having { :type :type } is a bit odd, don't you think?
         :string (Type/getType String)
         :object (Type/getType Object)
         :void Type/VOID_TYPE
@@ -241,7 +244,10 @@
         :long Type/LONG_TYPE
         :bool Type/BOOLEAN_TYPE
         (throw (ex-info (format  "[resolve-type] Unknown Keyword expr-type %s" expr-type) {:expr expr-type})))
-      (= t java.lang.String) (Type/getType (Class/forName expr-type))
+
+      (= t java.lang.String)
+      (Type/getType (Class/forName expr-type))
+
       :else
       (throw (ex-info (format  "[resolve-type] Unknown type %s" expr-type) {:expr expr-type})))))
 
@@ -586,11 +592,11 @@
       :fields [{:name "argIndex" :type :int}]}
      {:name "Math"
       :fields [{:name "op" :type :int}
-               {:name "opType" :type (Type/getType Type)}]}
+               {:name "opType" :type :asm-type}]}
      {:name "GetStaticField"
-      :fields [{:name "owner" :type (Type/getType Type)}
-               {:name "name" :type (Type/getType String)}
-               {:name "resultType" :type (Type/getType Type)}]}
+      :fields [{:name "owner" :type :asm-type}
+               {:name "name" :type :string}
+               {:name "resultType" :type :asm-type}]}
      {:name "Int"
       :fields [{:name "intValue" :type :int}]}
      {:name "Bool"

--- a/src/jml/core.clj
+++ b/src/jml/core.clj
@@ -460,10 +460,7 @@
 
 ;; NOTE: All names type combinations must be unique
 (defn make-enum [{:keys [class-name variants] :as description}]
-  (let [#_#_{:keys [class-name variants] :as description} (update description :variants
-                                                            (partial map
-                                                                     (comp (partial map resolve-props-type) :fields)))
-        writer (ClassWriter. (int (+ ClassWriter/COMPUTE_FRAMES ClassWriter/COMPUTE_MAXS)))]
+  (let [writer (ClassWriter. (int (+ ClassWriter/COMPUTE_FRAMES ClassWriter/COMPUTE_MAXS)))]
     (initialize-class writer class-name)
     (generate-default-constructor writer)
     (make-field writer {:name "tag" :type Type/INT_TYPE})


### PR DESCRIPTION
Working implementation of `resolve-type` function, that aims to retire those `Type/INT_TYPE` and  `(Type/getType (Class/forName ""))` from jml expressions. This PR allows replacing them with either 
- a set of predefined keywords, like `:int`, `:bool`, `:string`, `:object` etc. 
- a literal string interpreted as class name that resolves as `(Type/getType (Class/forName ""))` 
- you can still pass asm Type and it's a no-op
- asm Method object gets a special treatment, where I try to walk it's props and try to resolve their type to allow expressions like `(quote (Method. "invoke" :int [:int :int]))` but also already evaled `(Method. "invoke" Type/INT_TYPE [Type/INT_TYPE  Type/INT_TYPE]))` are accepted. This part maybe could use some rethinking, but it was useful to allow for the example below. 

Still work in progress, but it runs all of our rich comments and it allows writing below without all the quoting. so I thought it's probably good enough to share: 
```clojure


(run-multiple
 '(defn thing2 [:int :int :int]
    (plus-int (arg 0) (arg 1)))

 '(defn main [:void]
    (print (invoke-static {:owner "thing2"
                           :method (Method. "invoke" :int [:int :int])}
                          23 19)))
 )
```

Example of mixing different styles of types 
```clojure 
(make-struct {:class-name "Point"
              :fields [{:name "x" :type :int}
                       {:name "y" :type Type/INT_TYPE}]})


```

